### PR TITLE
Make ApiURL optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Here is an example of a configuration:
 ```swift
 let passwordlessClient = PasswordlessClient(
     config: PasswordlessConfig(
-        apiUrl: "https://v4.passwordless.dev",
         apiKey: "<YOUR API KEY>",
         rpId: "demo.passwordless.dev",
         origin: "https://demo.passwordless.dev"


### PR DESCRIPTION
@victor-livefront Can we make this url optional? You would only need to change it if you self-host, with is a more advanced usecase.