### PR TITLE
Discussion: Add matching overloads to JS client?

### DIFF
--- a/Sources/Passwordless/PasswordlessClient.swift
+++ b/Sources/Passwordless/PasswordlessClient.swift
@@ -75,6 +75,9 @@ public class PasswordlessClient {
     ///
     /// - Returns: A token that can be verified by the relying party backend.
     ///
+    public func signInWithAutofill(alias: String? = nil) async throws -> String {
+    public func signInWithUserId(alias: String? = nil) async throws -> String {
+    public func signInWithAlias(alias: String? = nil) async throws -> String {
     public func signIn(alias: String? = nil) async throws -> String {
         let signInResponse = try await apiService.signInBegin(alias: alias)
 


### PR DESCRIPTION
The JS client outlines three (actually 4) signin methods.
We might want to match that unless there is other concerns about that approach.

https://github.com/bitwarden/passwordless-client-js/blob/main/src/passwordless.ts#L91